### PR TITLE
Add 'connect with drivers' guides

### DIFF
--- a/documentation/connect-drivers-dotnet.adoc
+++ b/documentation/connect-drivers-dotnet.adoc
@@ -1,0 +1,51 @@
+== Installation
+
+The .NET driver is distributed via the NuGet Gallery. 
+To find the latest version of the driver, visit 
+link:https://www.nuget.org/packages/Neo4j.Driver/.
+
+== Connect to the database
+
+
+[source, csharp, role=nocollapse]
+----
+public class HelloWorldExample : IDisposable
+{
+    private readonly IDriver _driver;
+
+    public HelloWorldExample(string uri, string user, string password)
+    {
+        _driver = GraphDatabase.Driver(uri, AuthTokens.Basic(user, password));
+    }
+
+    public void PrintGreeting(string message)
+    {
+        using var session = _driver.Session();
+        var greeting = session.ExecuteWrite(
+            tx =>
+            {
+                var result = tx.Run(
+                    "CREATE (a:Greeting) " +
+                    "SET a.message = $message " +
+                    "RETURN a.message + ', from node ' + id(a)",
+                    new { message });
+
+                return result.Single()[0].As<string>();
+            });
+
+        Console.WriteLine(greeting);
+    }
+
+    public void Dispose()
+    {
+        _driver?.Dispose();
+    }
+
+    public static void Main()
+    {
+        using var greeter = new HelloWorldExample("{neo4j-database-uri}", "<Username>", "<Password>");
+
+        greeter.PrintGreeting("hello, world");
+    }
+}
+----

--- a/documentation/connect-drivers-go.adoc
+++ b/documentation/connect-drivers-go.adoc
@@ -1,0 +1,43 @@
+== Installation
+
+From within a module, use `go get` to install the link:https://pkg.go.dev/github.com/neo4j/neo4j-go-driver/v5/[Neo4j Go Driver]:
+
+[source, bash]
+----
+go get github.com/neo4j/neo4j-go-driver/v5
+----
+
+link:https://neo4j.com/docs/go-manual/current/install/#install-driver[More info on installing the driver ^]
+
+
+== Connect to the database
+
+Connect to a database by creating a `DriverWithContext` object and providing a URL and an authentication token.
+Once you have a `DriverWithContext` instance, use the `.VerifyConnectivity()` method to ensure that a working connection can be established.
+
+[source, go, role=nocollapse]
+----
+package main
+
+import (
+    "context"
+    "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+func main() {
+    ctx := context.Background()
+    // URI examples: "neo4j://localhost", "neo4j+s://xxx.databases.neo4j.io"
+    dbUri := "{neo4j-database-uri}"
+    dbUser := "<Username>"
+    dbPassword := "<Password>"
+    driver, err := neo4j.NewDriverWithContext(
+        dbUri,
+        neo4j.BasicAuth(dbUser, dbPassword, ""))
+    defer driver.Close(ctx)
+
+    err = driver.VerifyConnectivity(ctx)
+    if err != nil {
+        panic(err)
+    }
+}
+----

--- a/documentation/connect-drivers-java.adoc
+++ b/documentation/connect-drivers-java.adoc
@@ -1,0 +1,42 @@
+== Install Driver
+
+Add the Neo4j Java driver to the list of dependencies in the `pom.xml` of your Maven project:
+
+[source, xml, subs="attributes+"]
+----
+<dependency>
+    <groupId>org.neo4j.driver</groupId>
+    <artifactId>neo4j-java-driver</artifactId>
+    <version>5.20.0</version>
+</dependency>
+----
+
+link:https://neo4j.com/docs/java-manual/current/install/#install-driver[More info on installing the driver ^]
+
+== Connect to the database
+
+Connect to a database by creating a `Driver` object and providing a URL and an authentication token.
+Once you have a `Driver` instance, use the `.verifyConnectivity()` method to ensure that a working connection can be established.
+
+[source, java, role=nocollapse]
+----
+package demo;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.GraphDatabase;
+
+public class App {
+
+    public static void main(String... args) {
+
+        // URI examples: "neo4j://localhost", "neo4j+s://xxx.databases.neo4j.io"
+        final String dbUri = "{neo4j-database-uri}";
+        final String dbUser = "<Username>";
+        final String dbPassword = "<Password>";
+
+        try (var driver = GraphDatabase.driver(dbUri, AuthTokens.basic(dbUser, dbPassword))) {
+            driver.verifyConnectivity();
+        }
+    }
+}
+----

--- a/documentation/connect-drivers-javascript.adoc
+++ b/documentation/connect-drivers-javascript.adoc
@@ -1,0 +1,37 @@
+== Installation
+
+Install the Neo4j JavaScript driver with `npm`:
+
+[source,bash]
+----
+npm i neo4j-driver
+----
+
+link:https://neo4j.com/docs/javascript-manual/current/install/#install-driver[More info on installing the driver ^]
+
+
+== Connect to the database
+
+Connect to a database by creating a `Driver` object and providing a URL and an authentication token.
+Once you have a `Driver` instance, use the `.getServerInfo()` method to ensure that a working connection can be established by retrieving the server information.
+
+[source, javascript]
+----
+var neo4j = require('neo4j-driver');
+(async () => {
+  // URI examples: 'neo4j://localhost', 'neo4j+s://xxx.databases.neo4j.io'
+  const URI = '{neo4j-database-uri}'
+  const USER = '<Username>'
+  const PASSWORD = '<Password>'
+  let driver
+
+  try {
+    driver = neo4j.driver(URI, neo4j.auth.basic(USER, PASSWORD))
+    const serverInfo = await driver.getServerInfo()
+    console.log('Connection established')
+    console.log(serverInfo)
+  } catch(err) {
+    console.log(`Connection error\n${err}\nCause: ${err.cause}`)
+  }
+})();
+----

--- a/documentation/connect-drivers-python.adoc
+++ b/documentation/connect-drivers-python.adoc
@@ -1,0 +1,25 @@
+== Install Driver
+
+[source, bash]
+----
+pip install neo4j
+----
+
+link:https://neo4j.com/docs/python-manual/current/install/#install-driver[More info on installing the driver ^]
+
+== Connect to the Database
+
+Connect to a database by creating a `Driver` object and providing a URL and an authentication token.
+Once you have a `Driver` instance, use the `.verify_connectivity()` method to ensure that a working connection can be established.
+
+[source, python]
+----
+from neo4j import GraphDatabase
+
+# URI examples: "neo4j://localhost", "neo4j+s://xxx.databases.neo4j.io"
+URI = "{neo4j-database-uri}"
+AUTH = ("<Username>", "<Password>")
+
+with GraphDatabase.driver(URI, auth=AUTH) as driver:
+    driver.verify_connectivity()
+----


### PR DESCRIPTION
Adds guides for 'connect with drivers' modal.

Source: https://docs.google.com/document/d/1S37QN8xUWXo3HbUCiUv9AbKelM5bs2iTrOss4vnk_PM/

`{neo4j-database-uri}` template string in the `connect` guides will be substituted with Aura database instance URI.

<img width="983" alt="Screenshot 2024-05-28 at 09 34 14" src="https://github.com/neo4j/workspace-guides/assets/155437612/3b885b98-e40f-4e52-a5fb-6ab0fcd5b651">